### PR TITLE
Fix for PRE wrap

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -101,8 +101,8 @@ class syntax_plugin_dokucrypt2 extends DokuWiki_Syntax_Plugin {
                   "Toggle Visible</a>]\n" .
                   "<PRE id='$curid' class='dokucrypt2pre' style=\"" .
                      (($this->curLock["collapsed"] == 1) ?
-                        "visibility:hidden;position:absolute" :
-                        "visibility:visible;position:relative" ) .
+                        "visibility:hidden;position:absolute;white-space:pre-wrap" :
+                        "visibility:visible;position:relative;white-space:pre-wrap" ) .
                   "\">".hsc($match)."</PRE>";
                 $this->curNum++;
                 break;


### PR DESCRIPTION
Long lines do not wrap in PRE tag. This fix allows PRE tag to wrap long lines of text.