### PR TITLE
Fix #19: Don't use innerHTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -242,7 +242,7 @@ function toggleCryptDiv(elemid,lock,ctext) {
          alert("unable to find key for lock " + lock);
          return;
       }
-      elem.innerHTML=ptext;
+      elem.textContent=ptext;
       atag.innerHTML=ptStr;
       // make it visible
       elem.style.visibility="visible";


### PR DESCRIPTION
The encrypted text was inserted as innerHTML, which allows HTML content, but breaks if that is just plaintext with '<' in it.

If it is intended, that you can encrypt HTML tags, which then are inserted, don't merge this pull request. But if is is only intended for encrypted text, this would be the correct way.